### PR TITLE
fixed file size units

### DIFF
--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,5 +1,5 @@
 pub fn format_size(size: u64) -> String {
-    let units = ["B", "KB", "MB", "GB", "TB", "PB", "EB"];
+    let units = ["B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB"];
     let mut size = size as f64;
     let mut i = 0;
     while size >= 1024.0 && i < units.len() - 1 {


### PR DESCRIPTION
When dividing bytes by 1024, you are referring other units as Ki**bi**bytes, Me**bi**bytes, etc